### PR TITLE
update for ALS-304

### DIFF
--- a/psama-ui-overlay/src/main/webapp/psamaui/overrides/userProfile.js
+++ b/psama-ui-overlay/src/main/webapp/psamaui/overrides/userProfile.js
@@ -21,9 +21,11 @@ define(["handlebars", 'common/session', "picSure/userFunctions", "text!options/m
                 success: function(data){
                     notification.showSuccessMessage("password successfully changed");
                     $("#oldPassInput").val("");
-        	    	$("#newPassInput").val("");
-        	    	$("#confirmPassInput").val("");
+		        	    $("#newPassInput").val("");
+		        	    	$("#confirmPassInput").val("");	
         	    	
+		        	    	$("#modalDialog").hide();
+		        	    	
         	    	//update session to avoid showing this dialog again
         	    	session.setChangedPW();
         	    	


### PR DESCRIPTION
Simply hiding the modalDialog after a successful password changes fixes
this.